### PR TITLE
:memo: 포트설정 vite.config에서, prod용 Dockerfile생성

### DIFF
--- a/houssg/Dockerfile.prod
+++ b/houssg/Dockerfile.prod
@@ -1,0 +1,19 @@
+FROM node:18-alpine as builder
+
+WORKDIR /app
+
+COPY ["package.json", "package-lock.json*", "./"]
+
+RUN npm install
+
+COPY . .
+
+RUN npm run build 
+
+FROM nginx:1.25-alpine
+
+COPY --from=builder /app/dist/ /usr/share/nginx/html
+
+EXPOSE 80
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/houssg/package.json
+++ b/houssg/package.json
@@ -4,10 +4,10 @@
 	"version": "0.0.0",
 	"type": "module",
 	"scripts": {
-		"dev": "vite --port 8080",
+		"dev": "vite",
 		"build": "tsc && vite build",
 		"lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
-		"preview": "vite preview --port 8080"
+		"preview": "vite preview"
 	},
 	"dependencies": {
 		"@fullcalendar/core": "^6.1.8",


### PR DESCRIPTION
포트설정 vite.config에서, prod용 Dockerfile생성

### 개요

-  prod용 도커파일 생성

### 작업사항

- prod용 도커파일 생성

### 변경사항

-  port설정 위치 packagejson -> docker.prod

### Issue 번호

- #82 

close #82 