### PR TITLE
[✨ ]Feature/265 풀캘린더예약받기 풀캘린더 데이터 받기 및 css 관련 모달 및 리듀서 생성

### DIFF
--- a/houssg/src/components/common/CommonModal.tsx
+++ b/houssg/src/components/common/CommonModal.tsx
@@ -45,8 +45,8 @@ const CommonModal = () => {
 			{modalComp === 'declaration' && <DeclarationReview />}
 			{modalComp === 'houseComment' && <HouseComment />}
 			{modalComp === 'userReview' && <ReviewWrite />}
-			{modalComp === 'DeleRequest' && <DeleteRequestScreen />}
-			{modalComp === 'OwnerReservation' && <OwnerReservationModal />}
+			{modalComp === 'deleRequest' && <DeleteRequestScreen />}
+			{modalComp === 'ownerReservation' && <OwnerReservationModal />}
 			{(modalComp === 'instruction' || modalComp === 'couponRegistration') && <CommonInstruction />}
 		</Modal>
 	);

--- a/houssg/src/components/common/CommonModal.tsx
+++ b/houssg/src/components/common/CommonModal.tsx
@@ -12,6 +12,7 @@ import Terms from '../reservation/Terms';
 import CancelReservation from '../reservation/CancelReservation';
 import ReviewWrite from '../reservation/ReviewWrite';
 import { DeclarationReview, DeleteRequestScreen, HouseComment } from '../owner/management/element';
+import { OwnerReservationModal } from '../owner/reservation';
 
 const CommonModal = () => {
 	const modalState = useAppSelector(isModalOpen);
@@ -45,6 +46,7 @@ const CommonModal = () => {
 			{modalComp === 'houseComment' && <HouseComment />}
 			{modalComp === 'userReview' && <ReviewWrite />}
 			{modalComp === 'DeleRequest' && <DeleteRequestScreen />}
+			{modalComp === 'OwnerReservation' && <OwnerReservationModal />}
 			{(modalComp === 'instruction' || modalComp === 'couponRegistration') && <CommonInstruction />}
 		</Modal>
 	);

--- a/houssg/src/components/owner/management/ManageHouseRead.tsx
+++ b/houssg/src/components/owner/management/ManageHouseRead.tsx
@@ -21,7 +21,7 @@ const ManageHouseRead: React.FC<MyHouseDataHandleComp> = ({ house, setIsEditMode
 	};
 
 	const modalOpen = () => {
-		dispatch(openModal({ modalComponent: 'DeleRequest', modalSize: 300, modalText: 'house && ' + house.accomNumber }));
+		dispatch(openModal({ modalComponent: 'deleRequest', modalSize: 300, modalText: 'house && ' + house.accomNumber }));
 	};
 
 	return (

--- a/houssg/src/components/owner/management/element/RoomCompRead.tsx
+++ b/houssg/src/components/owner/management/element/RoomCompRead.tsx
@@ -16,7 +16,7 @@ const RoomCompRead: React.FC<RoomComp> = ({ room, setIsEditMode }) => {
 
 	const dispatch = useAppDispatch();
 	const modalOpen = () => {
-		dispatch(openModal({ modalComponent: 'DeleRequest', modalSize: 300, modalText: 'room && ' + room.accomNumber + ' && ' + room.roomNumber }));
+		dispatch(openModal({ modalComponent: 'deleRequest', modalSize: 300, modalText: 'room && ' + room.accomNumber + ' && ' + room.roomNumber }));
 	};
 
 	return (

--- a/houssg/src/components/owner/reservation/OwnerCalendar.tsx
+++ b/houssg/src/components/owner/reservation/OwnerCalendar.tsx
@@ -14,6 +14,7 @@ import { useRef } from 'react';
 import { changeYearMonth } from '../../../utils';
 import { useAppDispatch } from '../../../hooks';
 import { openModal } from '../../../store/redux/modalSlice';
+import { EventClickArg } from '@fullcalendar/core/index.js';
 
 const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData, houseId, isReservationList }) => {
 	const dispatch = useAppDispatch();
@@ -26,14 +27,21 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 	today.setHours(9, 0, 0, 0);
 	const calendarFullDate = new Date(calendarDate.year + '-' + calendarDate.month);
 
-	const modalOpen = (component: string, type: 'event' | 'date') => {
-		dispatch(openModal({ modalComponent: component, modalSize: 400, modalText: type }));
+	const modalOpen = (type: 'event' | 'date') => {
+		dispatch(openModal({ modalComponent: 'ownerReservation', modalSize: 400, modalText: type }));
 	};
-	console.log(modalOpen);
 	// 날짜를 클릭시
 	const handleDateClick = (args: DateClickArg) => {
+		modalOpen('date');
+
 		console.log(args.dateStr); // 날짜정보
 		console.log(args.dayEl.innerText); // 이벤트가 있으면 innerText가 /n이 들어가 있음
+	};
+
+	const handleEventClick = (arg: EventClickArg) => {
+		console.log(arg.event._def.title);
+		console.log(arg.event._instance?.range);
+		modalOpen('event');
 	};
 	//데이터 받기
 	const { isLoading, data, isSuccess, isError, error } = useQuery<{ data: OwnerReservedRoom[] }>(
@@ -111,9 +119,7 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 				plugins={[dayGridPlugin, interactionPlugin]}
 				initialView="dayGridMonth"
 				dateClick={handleDateClick}
-				eventClick={(arg) => {
-					console.log(arg);
-				}}
+				eventClick={handleEventClick}
 				ref={calendarRef}
 				aspectRatio={2}
 				dayMaxEvents={3}

--- a/houssg/src/components/owner/reservation/OwnerCalendar.tsx
+++ b/houssg/src/components/owner/reservation/OwnerCalendar.tsx
@@ -15,6 +15,7 @@ import { changeYearMonth } from '../../../utils';
 import { useAppDispatch } from '../../../hooks';
 import { openModal } from '../../../store/redux/modalSlice';
 import { EventClickArg } from '@fullcalendar/core/index.js';
+import { setCalendarModalInfo } from '../../../store/redux/calendarSlice';
 
 const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData, houseId, isReservationList }) => {
 	const dispatch = useAppDispatch();
@@ -32,6 +33,8 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 	};
 
 	const handleDateClick = (args: DateClickArg) => {
+		dispatch(setCalendarModalInfo({ calendarInfo: '넘오가나' }));
+
 		modalOpen(isReservationList ? 'reserve#date#' + args.dateStr : 'available#date#' + args.dateStr);
 
 		console.log(args.dateStr); // 날짜정보
@@ -39,6 +42,8 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 	};
 
 	const handleEventClick = (arg: EventClickArg) => {
+		dispatch(setCalendarModalInfo({ calendarInfo: '넘오가나 이벤트' }));
+
 		console.log(arg.event._def.title);
 		console.log(arg.event._instance?.range);
 		console.log(arg.event.id);

--- a/houssg/src/components/owner/reservation/OwnerCalendar.tsx
+++ b/houssg/src/components/owner/reservation/OwnerCalendar.tsx
@@ -13,16 +13,18 @@ import { getHouseReservation, getReservableRoomList } from '../../../helper';
 import { useRef } from 'react';
 import { changeYearMonth } from '../../../utils';
 
-const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData, houseId }) => {
+const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData, houseId, isReservationList }) => {
 	useCalendarStyle('owner');
 	const calendarRef = useRef<FullCalendar | null>(null);
 	// const calenderApi = calendarRef.current?.getApi().view.title; // 혹시 몰라 놔둠
 	const [calendarDate, setCalendarDate] = useState(currentDate);
 
-	console.log(calendarDate);
 	const { isLoading, data, isSuccess, isError, error } = useQuery<{ data: OwnerReservedRoom[] }>(
-		[ownerKey.getReservationData, houseId, calendarDate.year + '-' + calendarDate.month],
-		() => getHouseReservation(houseId, calendarDate.year + '-' + calendarDate.month),
+		[isReservationList ? ownerKey.getReservationData : ownerKey.reserveAvailability, houseId, calendarDate.year + '-' + calendarDate.month],
+		() =>
+			isReservationList
+				? getHouseReservation(houseId, calendarDate.year + '-' + calendarDate.month)
+				: getReservableRoomList(houseId, calendarDate.year + '-' + calendarDate.month),
 		{
 			cacheTime: 5 * 60 * 1000,
 			staleTime: 5 * 60 * 1000,
@@ -31,19 +33,8 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 		},
 	);
 
-	const reservationableRoomList = useQuery<{ data: OwnerReservedRoom[] }>(
-		[ownerKey.reserveAvailability, houseId, calendarDate.year + '-' + calendarDate.month],
-		() => getReservableRoomList(houseId, calendarDate.year + '-' + calendarDate.month),
-		{
-			cacheTime: 5 * 60 * 1000,
-			staleTime: 5 * 60 * 1000,
-			keepPreviousData: true,
-		},
-	);
-
 	isError && console.log(error, 'error');
 	isSuccess && console.log(data, '예약목록');
-	reservationableRoomList.isSuccess && console.log(reservationableRoomList.data, '예약가능목록');
 
 	if (isLoading) {
 		return <div>로딩중...</div>;
@@ -95,7 +86,7 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 				dayMaxEvents={3}
 				eventBackgroundColor={color.color3}
 				eventBorderColor="transparent"
-				// contentHeight={800}
+				contentHeight={800}
 			/>
 		</CalendarContainer>
 	);

--- a/houssg/src/components/owner/reservation/OwnerCalendar.tsx
+++ b/houssg/src/components/owner/reservation/OwnerCalendar.tsx
@@ -14,10 +14,15 @@ import { useRef } from 'react';
 import { changeYearMonth } from '../../../utils';
 
 const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData, houseId, isReservationList }) => {
-	useCalendarStyle('owner');
 	const calendarRef = useRef<FullCalendar | null>(null);
 	// const calenderApi = calendarRef.current?.getApi().view.title; // 혹시 몰라 놔둠
 	const [calendarDate, setCalendarDate] = useState(currentDate);
+	const [calendarEvents, setCalendarEvents] = useState<{ title: string; constraint?: string; start?: string; end?: string; date?: string }[]>([]);
+	// 날짜를 클릭시
+	const handleDateClick = (args: DateClickArg) => {
+		console.log(args.dateStr); // 날짜정보
+		console.log(args.dayEl.innerText); // 이벤트가 있으면 innerText가 /n이 들어가 있음
+	};
 
 	const { isLoading, data, isSuccess, isError, error } = useQuery<{ data: OwnerReservedRoom[] }>(
 		[isReservationList ? ownerKey.getReservationData : ownerKey.reserveAvailability, houseId, calendarDate.year + '-' + calendarDate.month],
@@ -33,17 +38,36 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 		},
 	);
 
-	isError && console.log(error, 'error');
-	isSuccess && console.log(data, '예약목록');
+	const calendarEvent = data?.data.map((event) => {
+		if (isReservationList) {
+			return { title: event.roomCategory, start: event.startDate, end: event.endDate, constraint: event.guestName + '님' };
+		}
+	});
+
+	// const calendarEvent = data?.data.map((event) => {
+	// 	if (isReservationList) {
+	// 		return { title: event.roomCategory, start: event.startDate, end: event.endDate, constraint: event.guestName + '님' };
+	// 	} else {
+	// 		const returnEvent = event.availabilityInfo.map((availabiity) => {
+	// 			return { title: event.roomCategory + `${availabiity.availableRooms}`, date: availabiity.date };
+	// 		});
+	// 		return { ...returnEvent };
+	// 	}
+	// });
+
+	// console.log(calendarEvent, '되나?');
+	useCalendarStyle('owner', data?.data);
+
+	isSuccess && console.log(data.data, isReservationList ? '예약목록' : '예약가능일');
+
+	if (isError) {
+		console.log(error);
+		alert('에러 발생');
+	}
 
 	if (isLoading) {
 		return <div>로딩중...</div>;
 	}
-	// 날짜를 클릭시
-	const handleDateClick = (args: DateClickArg) => {
-		console.log(args.dateStr); // 날짜정보
-		console.log(args.dayEl.innerText); // 이벤트가 있으면 innerText가 /n이 들어가 있음
-	};
 
 	return (
 		<CalendarContainer>
@@ -84,6 +108,7 @@ const OwnerCalendar: React.FC<CommonCalendarProps> = ({ currentDate, initailData
 				ref={calendarRef}
 				aspectRatio={2}
 				dayMaxEvents={3}
+				events={calendarEvent}
 				eventBackgroundColor={color.color3}
 				eventBorderColor="transparent"
 				contentHeight={800}

--- a/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
+++ b/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
@@ -1,0 +1,5 @@
+const OwnerReservationModal = () => {
+	return <div>OwnerReservationModal</div>;
+};
+
+export default OwnerReservationModal;

--- a/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
+++ b/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
@@ -1,15 +1,40 @@
+import styled from 'styled-components';
 import { useAppSelector } from '../../../hooks';
 import { modalText } from '../../../store/redux/modalSlice';
 
 const OwnerReservationModal = () => {
-	const text = useAppSelector(modalText);
+	const modalInfo = useAppSelector(modalText);
+	const typeArray = modalInfo.split('#');
+	const purposeType = typeArray[0];
+	const clickType = typeArray[1];
+	const dateInfo = typeArray[2];
+
+	const title =
+		purposeType === 'reserve'
+			? clickType === 'event'
+				? '예약 정보'
+				: dateInfo + ' 예약 목록'
+			: purposeType === 'available'
+			? clickType === 'event'
+				? '오프라인 예약추가'
+				: dateInfo + ' 이용가능 객실'
+			: '닫는중...';
 
 	return (
 		<div>
-			OwnerReservationModal
-			<div>{text}</div>
+			<OwnerReserveTitle>{title}</OwnerReserveTitle>
+			<div></div>
 		</div>
 	);
 };
 
 export default OwnerReservationModal;
+
+const OwnerReserveTitle = styled.div`
+	font-size: 1.2rem;
+	font-weight: 600;
+	margin-bottom: 1rem;
+	@media screen and (max-width: 600px) {
+		font-size: 1rem;
+	}
+`;

--- a/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
+++ b/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 import { useAppSelector } from '../../../hooks';
 import { modalText } from '../../../store/redux/modalSlice';
+import { calendarData } from '../../../store/redux/calendarSlice';
 
 const OwnerReservationModal = () => {
-	const modalInfo = useAppSelector(modalText);
-	const typeArray = modalInfo.split('#');
+	const calendarTypeInfo = useAppSelector(modalText);
+	const typeArray = calendarTypeInfo.split('#');
 	const purposeType = typeArray[0];
 	const clickType = typeArray[1];
 	const dateInfo = typeArray[2];
+	const calendarInfo = useAppSelector(calendarData);
 
 	const title =
 		purposeType === 'reserve'
@@ -23,7 +25,7 @@ const OwnerReservationModal = () => {
 	return (
 		<div>
 			<OwnerReserveTitle>{title}</OwnerReserveTitle>
-			<div></div>
+			<div>{calendarInfo}</div>
 		</div>
 	);
 };

--- a/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
+++ b/houssg/src/components/owner/reservation/OwnerReservationModal.tsx
@@ -1,5 +1,15 @@
+import { useAppSelector } from '../../../hooks';
+import { modalText } from '../../../store/redux/modalSlice';
+
 const OwnerReservationModal = () => {
-	return <div>OwnerReservationModal</div>;
+	const text = useAppSelector(modalText);
+
+	return (
+		<div>
+			OwnerReservationModal
+			<div>{text}</div>
+		</div>
+	);
 };
 
 export default OwnerReservationModal;

--- a/houssg/src/components/owner/reservation/ReservationDropDown.tsx
+++ b/houssg/src/components/owner/reservation/ReservationDropDown.tsx
@@ -46,10 +46,22 @@ export default ReservationDropDown;
 const DrowdownWrapper = styled.div`
 	margin: 1rem 0;
 	cursor: pointer;
-
+	box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
+	padding: 0.5rem;
+	border-radius: 0.5rem;
+	height: 3rem;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
 	.ant-space-item {
-		font-size: 1.5rem;
-		color: ${color.color1};
+		font-size: 1.1rem;
+		color: ${color.basicColor};
 		font-weight: 700;
+	}
+
+	@media screen and (max-width: 600px) {
+		.ant-space-item {
+			font-size: 0.65rem;
+		}
 	}
 `;

--- a/houssg/src/components/owner/reservation/index.ts
+++ b/houssg/src/components/owner/reservation/index.ts
@@ -1,3 +1,4 @@
 import ReservationDropDown from './ReservationDropDown';
 import OwnerCalendar from './OwnerCalendar';
-export { ReservationDropDown, OwnerCalendar };
+import OwnerReservationModal from './OwnerReservationModal';
+export { ReservationDropDown, OwnerCalendar, OwnerReservationModal };

--- a/houssg/src/hooks/useCalendarStyle.ts
+++ b/houssg/src/hooks/useCalendarStyle.ts
@@ -1,17 +1,18 @@
 import { useEffect } from 'react';
-import { UserType } from '../types';
+import { OwnerReservedRoom, UserType } from '../types';
 
-const useCalendarStyle = (type: UserType) => {
+const useCalendarStyle = (type: UserType, data: OwnerReservedRoom[] | undefined) => {
 	useEffect(() => {
 		if (type === 'owner') {
-			const parentDiv = document.getElementsByClassName('fc-daygrid-day-frame');
-			for (let i = 0; i < parentDiv.length; i++) {
-				if (parentDiv[i].children[1].children.length > 1) {
-					parentDiv[i].classList.add('calendar-unable');
-				}
-			}
+			// const parentDiv = document.getElementsByClassName('fc-daygrid-day-frame');
+			// for (let i = 0; i < parentDiv.length; i++) {
+			// 	// console.log(parentDiv[i].children[1].children);
+			// 	if (parentDiv[i].children[1].children.length <= 1) {
+			// 		parentDiv[i].classList.add('calendar-unable');
+			// 	}
+			// }
 		}
-	}, [type]);
+	}, [type, data]);
 };
 
 export default useCalendarStyle;

--- a/houssg/src/hooks/useCalendarStyle.ts
+++ b/houssg/src/hooks/useCalendarStyle.ts
@@ -1,18 +1,30 @@
 import { useEffect } from 'react';
-import { OwnerReservedRoom, UserType } from '../types';
 
-const useCalendarStyle = (type: UserType, data: OwnerReservedRoom[] | undefined) => {
+const useCalendarStyle = (isReservationList: boolean, houseId: number, today: Date | null) => {
 	useEffect(() => {
-		if (type === 'owner') {
-			// const parentDiv = document.getElementsByClassName('fc-daygrid-day-frame');
+		const parentDiv = document.getElementsByClassName('fc-daygrid-day-frame');
+		const dateDiv = document.getElementsByClassName('fc-daygrid-day-number');
+		if (today) {
+			for (let i = 0; i < dateDiv.length; i++) {
+				const targetDate = dateDiv[i].getAttribute('aria-label'); //ex ) 2023년 10월 1일
+				if (targetDate) {
+					const convertedString = targetDate.replace('년', '-').replace('월', '-').replace('일', '');
+					const convertedDate = new Date(convertedString);
+					convertedDate.setHours(9, 0, 0, 0);
+					convertedDate < today && parentDiv[i].classList.add('calendar-unable');
+				}
+			}
+		}
+
+		if (!isReservationList) {
+			// console.log(parentDiv);
 			// for (let i = 0; i < parentDiv.length; i++) {
-			// 	// console.log(parentDiv[i].children[1].children);
 			// 	if (parentDiv[i].children[1].children.length <= 1) {
 			// 		parentDiv[i].classList.add('calendar-unable');
 			// 	}
 			// }
 		}
-	}, [type, data]);
+	}, [isReservationList, houseId, today]);
 };
 
 export default useCalendarStyle;

--- a/houssg/src/layout/Nav.tsx
+++ b/houssg/src/layout/Nav.tsx
@@ -3,7 +3,6 @@ import { useNavigate } from 'react-router-dom'; // useLocation 추가
 import { color } from '../assets/styles/theme';
 import { useIsUser, usePathname } from '../hooks';
 import { StyledActiveProps } from '../types';
-import { devideOnce } from '../assets/styles';
 import { ownerRoute, userRoute } from '../assets/constant';
 
 const Nav = () => {
@@ -45,6 +44,13 @@ const NavContainer = styled.div`
 	display: flex;
 	align-items: center;
 	justify-content: space-evenly;
+	@media only screen and (max-width: 800px) {
+		height: 4rem;
+	}
+
+	@media only screen and (max-width: 400px) {
+		height: 3.8rem;
+	}
 `;
 
 const NavText = styled.div<StyledActiveProps>`
@@ -52,7 +58,11 @@ const NavText = styled.div<StyledActiveProps>`
 	font-weight: ${({ $active }) => ($active ? 800 : 500)};
 	color: ${color.backColor};
 	cursor: pointer;
-	@media only screen and (max-width: ${devideOnce.first}-35) {
+	@media only screen and (max-width: 800px) {
 		font-size: ${({ $active }) => ($active ? '1.1rem' : '0.8rem')};
+	}
+
+	@media only screen and (max-width: 400px) {
+		font-size: ${({ $active }) => ($active ? '0.9rem' : '0.65rem')};
 	}
 `;

--- a/houssg/src/pages/owner/OwnerReservation.tsx
+++ b/houssg/src/pages/owner/OwnerReservation.tsx
@@ -11,6 +11,8 @@ const OwnerReservation = () => {
 	const currentYear = today.getFullYear();
 	const currentMonth = today.getMonth() + 1;
 	const [houseIndex, setHouseIndex] = useState(0);
+	const [isReservationList, setIsReservationList] = useState(true);
+
 	const { isLoading, data, isSuccess, isError, error } = useQuery<{ data: CheckMyHouseReservationType }>(
 		[ownerKey.checkReservationList],
 		() => checkMyHouseReservation(currentYear + '-' + currentMonth),
@@ -32,11 +34,17 @@ const OwnerReservation = () => {
 		<OwnerReservationWrapper>
 			{isSuccess && (
 				<>
-					<ReservationDropDown accomList={data.data.accommodationList} houseIndex={houseIndex} setHouseIndex={setHouseIndex} />
+					<CalendarOptionContainer>
+						<ReservationDropDown accomList={data.data.accommodationList} houseIndex={houseIndex} setHouseIndex={setHouseIndex} />
+						<CalendarModeBtn onClick={() => setIsReservationList(!isReservationList)}>
+							{isReservationList ? '예약가능일 보기' : '예약내역 보기'}
+						</CalendarModeBtn>
+					</CalendarOptionContainer>
 					<OwnerCalendar
 						currentDate={{ year: currentYear, month: currentMonth }}
 						initailData={data.data.reservations}
 						houseId={data.data.accommodationList[houseIndex].accomNumber}
+						isReservationList={isReservationList}
 					/>
 				</>
 			)}
@@ -48,4 +56,35 @@ export default OwnerReservation;
 
 const OwnerReservationWrapper = styled.div`
 	margin: 1rem 0;
+`;
+
+const CalendarOptionContainer = styled.div`
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	gap: 1rem;
+	padding-inline: 16px;
+
+	@media screen and (max-width: 600px) {
+		gap: 0.7rem;
+		justify-content: space-between;
+		padding-inline: 4px;
+	}
+`;
+const CalendarModeBtn = styled.div`
+	font-size: 1.1rem;
+	font-weight: 600;
+	box-shadow: 0px 2px 2px rgba(0, 0, 0, 0.2);
+	padding: 0.5rem;
+	border-radius: 0.5rem;
+	height: 3rem;
+	width: 11rem;
+	@media screen and (max-width: 600px) {
+		width: 6rem;
+		font-size: 0.65rem;
+	}
+	display: flex;
+	justify-content: center;
+	align-items: center;
+	cursor: pointer;
 `;

--- a/houssg/src/store/redux/authSlice.ts
+++ b/houssg/src/store/redux/authSlice.ts
@@ -87,8 +87,7 @@ const authSlice = createSlice({
 				state.status = 'success';
 			})
 			.addCase(__postSignUp.rejected, (state) => {
-				// state.status = 'failed';
-				state.status = 'success';
+				state.status = 'failed';
 			});
 	},
 });

--- a/houssg/src/store/redux/calendarSlice.ts
+++ b/houssg/src/store/redux/calendarSlice.ts
@@ -1,0 +1,15 @@
+import { createSlice } from '@reduxjs/toolkit';
+
+const initialState = {
+	roomId: 0,
+	status: 'idle',
+	data: '',
+};
+
+const calendarSlice = createSlice({
+	name: 'calendar',
+	initialState,
+	reducers: {},
+});
+
+export default calendarSlice.reducer;

--- a/houssg/src/store/redux/calendarSlice.ts
+++ b/houssg/src/store/redux/calendarSlice.ts
@@ -1,15 +1,28 @@
 import { createSlice } from '@reduxjs/toolkit';
+import { RootState } from '.';
 
-const initialState = {
-	roomId: 0,
+export interface CalendarState {
+	status: 'idle' | 'loading' | 'failed' | 'success';
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	calendarInfo: any;
+}
+
+const initialState: CalendarState = {
 	status: 'idle',
-	data: '',
+	calendarInfo: '',
 };
 
 const calendarSlice = createSlice({
 	name: 'calendar',
 	initialState,
-	reducers: {},
+	reducers: {
+		setCalendarModalInfo: (state, action) => {
+			state.calendarInfo = action.payload.calendarInfo;
+		},
+	},
 });
+
+export const { setCalendarModalInfo } = calendarSlice.actions;
+export const calendarData = (state: RootState) => state.calendar.calendarInfo;
 
 export default calendarSlice.reducer;

--- a/houssg/src/store/redux/index.ts
+++ b/houssg/src/store/redux/index.ts
@@ -2,11 +2,13 @@
 import { configureStore } from '@reduxjs/toolkit';
 import modalReducer from './modalSlice';
 import authReducer from './authSlice';
+import calendarReducer from './calendarSlice';
 
 export const store = configureStore({
 	reducer: {
 		modal: modalReducer,
 		auth: authReducer,
+		calendar: calendarReducer,
 	},
 });
 

--- a/houssg/src/store/redux/modalSlice.ts
+++ b/houssg/src/store/redux/modalSlice.ts
@@ -9,7 +9,6 @@ export interface ModalState {
 	modalProps?: {
 		[key: string]: string | number | boolean;
 	};
-	//TODO: 추후 타입지정
 	// eslint-disable-next-line @typescript-eslint/no-explicit-any
 	modalFunc?: any;
 }

--- a/houssg/src/types/ownerReservation.ts
+++ b/houssg/src/types/ownerReservation.ts
@@ -27,6 +27,7 @@ interface CommonCalendarProps {
 	currentDate: { year: number; month: number };
 	houseId: number;
 	initailData: OwnerReservedRoom[];
+	isReservationList: boolean;
 }
 
 export type { OwnerReservedRoom, OwnerAvailableRoom, CommonCalendarProps, CheckMyHouseReservationType };

--- a/houssg/src/types/ownerReservation.ts
+++ b/houssg/src/types/ownerReservation.ts
@@ -5,6 +5,7 @@ interface OwnerReservedRoom {
 	endDate: string;
 	guestName: string;
 	guestPhone: string;
+	reservationNumber: number;
 	availabilityInfo: [
 		{
 			date: string;

--- a/houssg/src/types/ownerReservation.ts
+++ b/houssg/src/types/ownerReservation.ts
@@ -5,6 +5,12 @@ interface OwnerReservedRoom {
 	endDate: string;
 	guestName: string;
 	guestPhone: string;
+	availabilityInfo: [
+		{
+			date: string;
+			availableRooms: number;
+		},
+	];
 }
 
 interface OwnerAvailableRoom {


### PR DESCRIPTION
### 개요

- 풀캘린더예약받기 풀캘린더 데이터 받기 및 css 관련 모달 및 리듀서 생성

### 작업사항

- 1  사업자 페이지 날짜가 지난 데이터 필터링
- 2  커스텀 버튼을 통해서 날짜 이동시 현재 시간 얻기
- 3  지난 날짜에 대한 표시 disabled표시
- 4 이벤트 및 날짜 클릭시 모달 뜨기
- 5 달력 모달에 데이터 넘겨줄 calendarSlice 생성(rtk)

### Issue 번호

- close #265