### PR TITLE
[✨ ] Feature/284 refresh token  axios instance로 jwt  accesss토큰  만료시 처리

### DIFF
--- a/houssg/src/api/api.ts
+++ b/houssg/src/api/api.ts
@@ -15,7 +15,6 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig<{ headers: stri
 	if (access_token !== null) {
 		const invalidate = sessionStorage.getItem('invalidate');
 		if (!invalidate) {
-			console.log('첫 요청시');
 			config.headers['Authorization'] = access_token;
 		} else {
 			const refreshtoken = sessionStorage.getItem('refreshtoken');

--- a/houssg/src/api/api.ts
+++ b/houssg/src/api/api.ts
@@ -14,8 +14,10 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig<{ headers: stri
 
 	if (access_token !== null) {
 		const invalidate = sessionStorage.getItem('invalidate');
-		config.headers['Authorization'] = access_token;
-		if (invalidate !== null) {
+		if (!invalidate) {
+			console.log('첫 요청시');
+			config.headers['Authorization'] = access_token;
+		} else {
 			const refreshtoken = sessionStorage.getItem('refreshtoken');
 			config.headers['Refreshtoken'] = refreshtoken;
 		}
@@ -24,7 +26,15 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig<{ headers: stri
 });
 
 api.interceptors.response.use(
-	(response) => response,
+	(response) => {
+		if (response.headers.authorization) {
+			sessionStorage.setItem('authorization', response.headers.authorization);
+			sessionStorage.setItem('refreshtoken', response.headers.refreshtoken);
+			sessionStorage.removeItem('invalidate');
+		}
+
+		return response;
+	},
 	(error) => {
 		if (error.response && error.response.status) {
 			switch (error.response.status) {

--- a/houssg/src/api/api.ts
+++ b/houssg/src/api/api.ts
@@ -13,7 +13,12 @@ api.interceptors.request.use((config: InternalAxiosRequestConfig<{ headers: stri
 	const access_token = sessionStorage.getItem('authorization');
 
 	if (access_token !== null) {
+		const invalidate = sessionStorage.getItem('invalidate');
 		config.headers['Authorization'] = access_token;
+		if (invalidate !== null) {
+			const refreshtoken = sessionStorage.getItem('refreshtoken');
+			config.headers['Refreshtoken'] = refreshtoken;
+		}
 	}
 	return config;
 });
@@ -23,6 +28,9 @@ api.interceptors.response.use(
 	(error) => {
 		if (error.response && error.response.status) {
 			switch (error.response.status) {
+				case 401:
+					sessionStorage.setItem('invalidate', 'invalidate');
+					break;
 				case 500:
 					alert('서버에 문제가 있습니다.');
 					break;


### PR DESCRIPTION
### 개요

- axios instance로 jwt  accesss토큰  만료시 처리 (request와 response 활용)

### 작업사항
1 401에러가 뜰 경우 invalidate라는 값을 session 에 저장
 2 invalidate 존재시 refresh토큰 전송
 3 성공시 토큰이 있다면 저장


### Issue 번호

-  close #284