### PR TITLE
:zap: Feature/312 찜

### DIFF
--- a/houssg/src/components/common/HeartIcons.tsx
+++ b/houssg/src/components/common/HeartIcons.tsx
@@ -12,9 +12,10 @@ import { userKey } from '../../assets/constant/queryKey';
 
 interface HeartIconsProps {
 	houseId: number;
+	beforePage: string;
 }
-const HeartIcons: React.FC<HeartIconsProps> = ({ houseId }) => {
-	const [isLike, setIsLike] = useState<boolean>(false);
+const HeartIcons: React.FC<HeartIconsProps> = ({ houseId, beforePage }) => {
+	const [isLike, setIsLike] = useState<boolean>(beforePage === 'houseDetail' ? false : true);
 
 	const dispatch = useAppDispatch();
 	const isLogin = useAppSelector(isLoginState);
@@ -37,12 +38,14 @@ const HeartIcons: React.FC<HeartIconsProps> = ({ houseId }) => {
 
 	useEffect(() => {
 		if (isLogin) {
-			try {
-				api.get(userUrl.like, { params: { accomNumber: houseId } }).then(({ data }) => {
-					setIsLike(data);
-				});
-			} catch (err) {
-				console.log('라이크 첫 렌더링 시 로그인 상태면 실행되는 get 리스펀스 > ', err);
+			if (beforePage === 'houseDetail') {
+				try {
+					api.get(userUrl.like, { params: { accomNumber: houseId } }).then(({ data }) => {
+						setIsLike(data);
+					});
+				} catch (err) {
+					console.log('라이크 첫 렌더링 시 로그인 상태면 실행되는 get 리스펀스 > ', err);
+				}
 			}
 		}
 	}, []);

--- a/houssg/src/components/house/HouseInfo.tsx
+++ b/houssg/src/components/house/HouseInfo.tsx
@@ -36,7 +36,7 @@ export const HouseInfo: React.FC<HouseProps> = ({ house }) => {
 			<AccomImg>
 				<Img src={house.img} />
 				<OverHeartIcon>
-					<HeartIcons houseId={house.accomNumber} />
+					<HeartIcons houseId={house.accomNumber} beforePage="houseDetail" />
 				</OverHeartIcon>
 			</AccomImg>
 			<Info>

--- a/houssg/src/components/usermypages/MyFavorite.tsx
+++ b/houssg/src/components/usermypages/MyFavorite.tsx
@@ -25,14 +25,13 @@ const MyFavorite = () => {
 	if (isLoading) {
 		return <div>로딩중...</div>;
 	}
-	console.log(data);
 	return (
 		isSuccess && (
 			<MyFavoriteWrapper>
 				{data.data.length !== 0 ? (
 					<>
-						{data.data.map((favorites, i) => (
-							<div key={i}>
+						{data.data.map((favorites) => (
+							<div key={favorites.accomNumber}>
 								<MyFavoriteContainer>
 									<HouseNameBox>
 										<span
@@ -49,7 +48,7 @@ const MyFavorite = () => {
 										<div>{favorites.accomAddress}</div>
 									</HouseAddressBox>
 									<FavoriteContainer>
-										<HeartIcons houseId={favorites.accomNumber} />
+										<HeartIcons houseId={favorites.accomNumber} beforePage="myFavorite" />
 									</FavoriteContainer>
 								</MyFavoriteContainer>
 							</div>


### PR DESCRIPTION
### 개요

- 개요

### 작업사항

- 마이 페이지 - 찜한 숙소에서는 get으로 찜 여부를 받는게 불필요한 API 통신
-> 분기처리 해서 호출되는 페이지에 맞게 찜 여부를 get하기
- 이슈 :숙소의 찜이 해제됐을 때 찜해제된 하트 아이콘이 남아있음
-> 리팩토링 : map key를 map에서 제공되는 index가 아닌 map으로 돌아가는 데이터의 unique 데이터로 설정
-> 숙소가 해제되면 찜이 풀린 아이콘도 같이 사라짐

### 변경사항

- 변경사항

### Issue 번호

- close #312 