### PR TITLE
:bug: Feature/317 예약하기 디버깅

### DIFF
--- a/houssg/src/components/reservation/PaymentWidget.tsx
+++ b/houssg/src/components/reservation/PaymentWidget.tsx
@@ -26,14 +26,20 @@ const PaymentWidget: React.FC<PaymentWidgetProps> = ({ selectedReservation }) =>
 
 	const queryClient = useQueryClient();
 
+	const [sign, setSign] = useState('');
+
 	const { mutate } = useMutation({
 		mutationFn: ({ reservationNumber, sign }: UserReservationIsSuccessType) => userReservationIsSuccess({ reservationNumber, sign }),
 		onSuccess: () => {
 			queryClient.invalidateQueries({ queryKey: [userKey.myReservation] });
-			alert('예약이 완료되었습니다.');
+			if (sign === 'success') {
+				alert('예약이 완료되었습니다.');
+			}
 		},
 		onError: () => {
-			alert('죄송합니다. 예약 완료에 문제가 발생했습니다. houssg 고객센터로 문의 부탁드립니다.');
+			if (sign === 'success') {
+				alert('죄송합니다. 예약 완료에 문제가 발생했습니다. houssg 고객센터로 문의 부탁드립니다.');
+			}
 		},
 	});
 
@@ -80,11 +86,7 @@ const PaymentWidget: React.FC<PaymentWidgetProps> = ({ selectedReservation }) =>
 			return;
 		}
 
-		if (
-			selectedReservation.usingCoupon.discount !== 0 ||
-			(selectedReservation.usingPoint !== 0 &&
-				selectedReservation.paymentPrice < selectedReservation.usingCoupon.discount + selectedReservation.usingPoint)
-		) {
+		if (selectedReservation.paymentPrice < 0) {
 			alert('쿠폰 및 포인트의 사용 총액이 결제할 금액보다 많은 경우는 결제가 불가합니다.');
 			return;
 		}
@@ -121,6 +123,7 @@ const PaymentWidget: React.FC<PaymentWidgetProps> = ({ selectedReservation }) =>
 							})
 							.then(function () {
 								mutate({ reservationNumber: reservationNumFromBack, sign: 'success' });
+								setSign('success');
 								// 포인트 사용시, 세션에 포인트도 업데이트
 								if (selectedReservation.usingPoint > 0) {
 									sessionStorage.setItem('point', originPoint - selectedReservation.usingPoint + '');
@@ -140,6 +143,7 @@ const PaymentWidget: React.FC<PaymentWidgetProps> = ({ selectedReservation }) =>
 									alert('한도초과 혹은 잔액부족으로 결제에 실패했습니다.');
 								}
 								mutate({ reservationNumber: reservationNumFromBack, sign: 'fail' });
+								setSign('fail');
 							});
 				});
 		} catch (err) {


### PR DESCRIPTION
### 개요

- 개요

### 작업사항

- 이슈 1
정상적인 로직 : 할인 금액 > 예약 원가 일 때 , 결제 불가 안내창이 떠야하는데
변경 전 : 할인 금액 > 예약 원가/2 일 때, 결제 불가 안내창이 뜸
원인 :  예약 원가에서 이미 할인가를 계산한 실결제금액 이랑 할인 금액 비교해서 알러트를 띄워주도록 짜져있었음
해결 : 실결제금액이 0보다 작으면 예약 원가보다 할인가가 크다는 거니까 , 조건을 변경

- 이슈 2
정상적인 로직 : 결제 성공을 백에 전송한 통신이 성공 시, 예약 완료 안내창 띄우기
                          결제 성공을 백에 전송한 통신이 실패 시, 사이트에 문의하라는 안내창 띄우기
                          결제 실패를 백에 전송한 통신은 실패해도 추후 백이 처리할거라 일단 전송만 하고 통신 성공, 실패는 유저한테 안 알려도 됨
변경 전 : 결제 성공이든 실패든 결제 성공 여부 통신이 성공하면 예약 완료 안내창을 띄움
원인 : 예약 완료 안내창 띄우는 코드를 결제 성공 여부 통신 성공 시 실행되게 코드 짬
해결 : 통신이 성공,실패 시, 결제가 성공일 때 안내창 띄우도록 분기 처리

### 변경사항

- 변경사항

### Issue 번호

- close #317 